### PR TITLE
Added <climits> to BattleScript.cpp so it compiles on Linux

### DIFF
--- a/src/Mod/BattleScript.cpp
+++ b/src/Mod/BattleScript.cpp
@@ -23,6 +23,7 @@
 #include "../Engine/Exception.h"
 #include "../Engine/Logger.h"
 #include "../Mod/RuleTerrain.h"
+#include <climits>
 
 
 namespace OpenXcom


### PR DESCRIPTION
Compile Process crashed on Mod/BattleScript.cpp due to missing definition for INT_MAX.
By including climits INT_MAX is definied. The compilation was successful afterwards.