### PR TITLE
Update to Evacuation mission debriefing conditions

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -1966,10 +1966,10 @@ void DebriefingState::prepareDebriefing()
 	}
 	// Extended mission types handling
 	int extraPoints = 0;
-	if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_EVACUATION" && (vipsLost > 0 || vipsSaved > 0))
+	if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_EVACUATION")
 	{
 		success = true;
-		if (vipsSaved == 0 || (vipsSaved * 4) < vipsLost)
+		if ((vipsLost > 0 && (vipsSaved * 4) < vipsLost) || (vipsSaved == 0 && playersSurvived == 0)) // if we saved too few VIPs or if there were no VIPs and we lost all soldiers
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_FAILED"));
 			success = false;
@@ -1978,7 +1978,7 @@ void DebriefingState::prepareDebriefing()
 				addStat(objectiveFailedText, 1, objectiveFailedScore);
 			}
 		}
-		else if (vipsLost == 0 || (vipsLost * 4) < vipsSaved)
+		else if ((vipsSaved > 0 && (vipsLost * 4) < vipsSaved) || (vipsLost == 0 && deadSoldiers == 0 && playersMIA == 0)) // if we saved enough VIPs or if there were no VIPs and we saved all soldiers
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_SUCCESSFUL"));
 			if (!objectiveCompleteText.empty())
@@ -1986,7 +1986,7 @@ void DebriefingState::prepareDebriefing()
 				addStat(objectiveCompleteText, 1, objectiveCompleteScore);
 			}
 		}
-		else
+		else // any other combination
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_COMPLETE"));
 		}


### PR DESCRIPTION
Added logic to handle evacuation of player soldiers and not VIPs

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->