### PR TITLE
#81 Evacuation results bug fix

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -1652,6 +1652,7 @@ void DebriefingState::prepareDebriefing()
 					if (evacObj)
 					{
 						addStat("STR_VIP_LOST", 1, - (value * 2));
+						++vipsLost;
 						//handleVipRecovery((*j), _base, false);
 					}
 					else
@@ -1972,10 +1973,10 @@ void DebriefingState::prepareDebriefing()
 	}
 	// Extended mission types handling
 	int extraPoints = 0;
-	if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_EVACUATION")
+	if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_EVACUATION" && (vipsLost > 0 || vipsSaved > 0))
 	{
 		success = true;
-		if ((vipsLost > 0 && (vipsSaved * 4) < vipsLost) || (vipsSaved == 0 && playersSurvived == 0)) // if we saved too few VIPs or if there were no VIPs and we lost all soldiers
+		if (vipsSaved == 0 || (vipsSaved * 4) < vipsLost)
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_FAILED"));
 			success = false;
@@ -1984,7 +1985,7 @@ void DebriefingState::prepareDebriefing()
 				addStat(objectiveFailedText, 1, objectiveFailedScore);
 			}
 		}
-		else if ((vipsSaved > 0 && (vipsLost * 4) < vipsSaved) || (vipsLost == 0 && deadSoldiers == 0 && playersMIA == 0)) // if we saved enough VIPs or if there were no VIPs and we saved all soldiers
+		else if (vipsLost == 0 || (vipsLost * 4) < vipsSaved)
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_SUCCESSFUL"));
 			if (!objectiveCompleteText.empty())
@@ -1992,9 +1993,34 @@ void DebriefingState::prepareDebriefing()
 				addStat(objectiveCompleteText, 1, objectiveCompleteScore);
 			}
 		}
-		else // any other combination
+		else
 		{
 			_txtTitle->setText(tr("STR_EVACUATION_COMPLETE"));
+		}
+	}
+	else if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_EXTRACTION")
+	{
+		success = true;
+		if (playersSurvived == 0)
+		{
+			_txtTitle->setText(tr("STR_EXTRACTION_FAILED"));
+			success = false;
+			if (!objectiveFailedText.empty())
+			{
+				addStat(objectiveFailedText, 1, objectiveFailedScore);
+			}
+		}
+		else if (deadSoldiers == 0 && playersMIA == 0)
+		{
+			_txtTitle->setText(tr("STR_EXTRACTION_SUCCESSFUL"));
+			if (!objectiveCompleteText.empty())
+			{
+				addStat(objectiveCompleteText, 1, objectiveCompleteScore);
+			}
+		}
+		else
+		{
+			_txtTitle->setText(tr("STR_EXTRACTION_COMPLETE"));
 		}
 	}
 	else if (ruleDeploy && ruleDeploy->getExtendedObjectiveType() == "STR_ITEM_EXTRACTION" && (_game->getSavedGame()->getSavedBattle()->getItemObjectivesNumber() > 0))


### PR DESCRIPTION
- Separated VIP evacuation and Soldier extraction mission types
- VIP that are missing in action when mission is aborted now count as lost

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->