### PR TITLE
Local extended item reload cost

### DIFF
--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -145,7 +145,7 @@ const float TilesToVexels = 16.0f;
  */
 RuleItem::RuleItem(const std::string &type) :
 	_type(type), _name(type), _vehicleUnit(nullptr), _size(0.0), _costBuy(0), _costSell(0), _costDispose(0), _transferTime(24), _weight(3), _throwRange(0), _underwaterThrowRange(0),
-	_stackSize(1),
+	_stackSize(1), _extendedItemReloadCostLocal(0),
 	_bigSprite(-1), _floorSprite(-1), _handSprite(120), _bulletSprite(-1), _specialIconSprite(-1),
 	_hitAnimation(0), _hitAnimFrames(-1), _hitMissAnimation(-1), _hitMissAnimFrames(-1),
 	_meleeAnimation(0), _meleeAnimFrames(-1), _meleeMissAnimation(-1), _meleeMissAnimFrames(-1),
@@ -334,6 +334,12 @@ void RuleItem::loadConfAction(RuleItemAction& a, const YAML::Node& node, const s
 	}
 }
 
+/// Load ExtendedItemReloadCostLocal from yaml.
+void RuleItem::loadExtendedItemReloadCostLocal(const YAML::Node& node)
+{
+	_extendedItemReloadCostLocal = node["extendedItemReloadCostLocal"].as<int>(_extendedItemReloadCostLocal);
+}
+
 /**
  * Load RuleItemFuseTrigger from yaml.
  */
@@ -398,6 +404,7 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 	_stackSize = node["stackSize"].as<int>(_stackSize);
 	_missionObjective = node["missionObjective"].as<bool>(_missionObjective);
 	_alienArtifact = node["alienArtifact"].as<bool>(_alienArtifact);
+	_extendedItemReloadCostLocal = node["extendedItemReloadCostLocal"].as<int>(_extendedItemReloadCostLocal);
 
 	mod->loadSpriteOffset(_type, _bigSprite, node["bigSprite"], "BIGOBS.PCK");
 	mod->loadSpriteOffset(_type, _floorSprite, node["floorSprite"], "FLOOROB.PCK");

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -411,6 +411,7 @@ private:
 	RuleStatBonus _damageBonus, _meleeBonus, _accuracyMulti, _meleeMulti, _throwMulti, _closeQuartersMulti;
 	ModScript::BattleItemScripts::Container _battleItemScripts;
 	ScriptValues<RuleItem> _scriptValues;
+	int _extendedItemReloadCostLocal;
 
 	/// Get final value of cost.
 	RuleItemUseCost getDefault(const RuleItemUseCost& a, const RuleItemUseCost& b) const;
@@ -430,6 +431,8 @@ private:
 	int getRandomSound(const std::vector<int> &vector, int defaultValue = -1) const;
 	/// Load RuleItemFuseTrigger from yaml.
 	void loadConfFuse(RuleItemFuseTrigger& a, const YAML::Node& node, const std::string& name) const;
+	/// Load ExtendedItemReloadCostLocal from yaml.
+	void loadExtendedItemReloadCostLocal(const YAML::Node& node);
 
 public:
 	/// Name of class used in script.
@@ -448,6 +451,8 @@ public:
 	/// Cross link with other rules.
 	void afterLoad(const Mod* mod);
 
+    /// Gets reload cost
+	int getExtendedItemReloadCostLocal() const {return _extendedItemReloadCostLocal;}
 	/// Gets the item's type.
 	const std::string &getType() const;
 	/// Gets the item's name.


### PR DESCRIPTION
<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->New logic for reload cost