### PR TITLE
Hitlog nerf, spotter nerf

### DIFF
--- a/src/Battlescape/AIModule.cpp
+++ b/src/Battlescape/AIModule.cpp
@@ -428,6 +428,13 @@ void AIModule::think(BattleAction *action)
 		action->target = _patrolAction.target;
 		break;
 	case AI_COMBAT:
+		if (_save->isStealthMission() && _save->getAlarmLevel() == 0 && _save->getGeoscapeSave()->getDifficulty() < 3)
+		{
+			action->type = _attackAction.type = BA_NONE;
+			action->finalAction = true;
+		}
+		else
+		{
 		action->type = _attackAction.type;
 		action->target = _attackAction.target;
 		// this may have changed to a grenade.
@@ -454,6 +461,7 @@ void AIModule::think(BattleAction *action)
 		else if (action->type == BA_AIMEDSHOT || action->type == BA_AUTOSHOT)
 		{
 			action->kneel = _unit->getArmor()->allowsKneeling(false);
+		}
 		}
 		break;
 	case AI_AMBUSH:

--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -985,7 +985,6 @@ void ProjectileFlyBState::projectileHitUnit(Position pos)
 			{
 				ai->setWasHitBy(_unit);
 				_unit->setTurnsSinceSpotted(0);
-				_unit->setTurnsLeftSpottedForSnipers(std::max(victim->getSpotterDuration(), _unit->getTurnsLeftSpottedForSnipers()));
 			}
 		}
 	}

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2532,7 +2532,7 @@ bool TileEngine::hitUnit(BattleActionAttack attack, BattleUnit *target, const Po
 	const int stunDamage = target->getStunlevel() - stunLevelOrig;
 
 	// hit log
-	if (attack.attacker)
+	if (attack.attacker && target->getVisible())
 	{
 		if (healthDamage > 0 || stunDamage > 0)
 		{


### PR DESCRIPTION
1. Hitlog is no longer applicable to enemies you don't see
2. Spotters don't mark you when you hit then.