### PR TITLE
Update DebriefingState.cpp

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -2051,6 +2051,15 @@ void DebriefingState::prepareDebriefing()
 				{
 					addStat(objectiveCompleteText, 1, objectiveCompleteScore);
 				}
+				//discard abort penalty. it's legal here
+				for (std::vector<DebriefingStat *>::iterator i = _stats.begin(); i != _stats.end(); ++i)
+				{
+					if ((*i)->item == "STR_MISSION_ABORTED")
+					{
+						_stats.erase(i);
+						break;
+					}
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Discard abort penalty in successful STR_EVACUATION missions

issue: https://github.com/723Studio/OpenXcom_FTA/issues/108

tested with STR_SCIENTIST_REFUGE mission( + uncommented "abortPenalty 300" there). 

I've set up
vipsSaved = 10;
vipsLost = 0;
in the code to pretend the mission is a success.

abort report before:
<img width="761" alt="issue_108_as_is" src="https://user-images.githubusercontent.com/40729091/202469051-f11abab2-cbc8-48ff-915f-6ad214ff0352.png">

abort report after:
<img width="761" alt="issue_108_to_be" src="https://user-images.githubusercontent.com/40729091/202469084-b27df632-a244-4f2b-916d-b3cd7db9e36d.png">
