### PR TITLE
Add ruleset-driven diplomacy dialogue system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,7 @@ set ( engine_src
 )
 
 set ( fta_src
+  FTA/DiplomacyDialogueState.cpp
   FTA/DiplomacyHirePersonnelState.cpp
   FTA/DiplomacyPurchaseState.cpp
   FTA/DiplomacySellState.cpp
@@ -370,6 +371,7 @@ set ( mod_src
   Mod/RuleDamageType.cpp
   Mod/RuleDiplomacyFaction.cpp
   Mod/RuleDiplomacyFactionEvent.cpp
+  Mod/RuleDiplomacyAction.cpp
   Mod/RuleEnviroEffects.cpp
   Mod/RuleEvent.cpp
   Mod/RuleEventScript.cpp

--- a/src/FTA/DiplomacyDialogueState.cpp
+++ b/src/FTA/DiplomacyDialogueState.cpp
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2010-2026 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "DiplomacyDialogueState.h"
+#include "DiplomacyHirePersonnelState.h"
+#include "DiplomacyStartState.h"
+#include <algorithm>
+#include "../Engine/Game.h"
+#include "../Engine/Action.h"
+#include "../Engine/Logger.h"
+#include "../Engine/InteractiveSurface.h"
+#include "../Engine/RNG.h"
+#include "../Interface/Text.h"
+#include "../Interface/TextList.h"
+#include "../Mod/Mod.h"
+#include "../Mod/RuleDiplomacyFaction.h"
+#include "../Mod/RuleDiplomacyAction.h"
+#include "../Savegame/SavedGame.h"
+#include "../Savegame/DiplomacyFaction.h"
+#include "../Savegame/Base.h"
+#include "../FTA/MasterMind.h"
+#include "../Geoscape/GeoscapeState.h"
+
+namespace OpenXcom
+{
+
+namespace
+{
+	DiplomacyFaction* findFactionByRules(SavedGame& save, const RuleDiplomacyFaction* rules)
+	{
+		if (!rules)
+		{
+			return nullptr;
+		}
+		for (auto* f : save.getDiplomacyFactions())
+		{
+			if (f && f->getRules() == rules)
+			{
+				return f;
+			}
+		}
+		return nullptr;
+	}
+
+	bool isCpalSurfaceName(const std::string& name)
+	{
+		return name.find("_CPAL") != std::string::npos;
+	}
+
+} // namespace
+
+DiplomacyDialogueState::DiplomacyDialogueState(Base* base, DiplomacyFaction* faction)
+	: _base(base), _faction(faction), _bg(nullptr), _txtReply(nullptr), _lstActions(nullptr), _txtCloseHint(nullptr), _txtTooltip(nullptr), _exitMode(false), _exitModeIgnoreEvent(nullptr)
+{
+	_screen = true;
+
+	// UI skeleton (no window, no standard buttons)
+	_bg = new InteractiveSurface(320, 200, 0, 0);
+	_txtReply = new Text(160, 98, 2, 2);
+	_lstActions = new TextList(160, 96, 2, 102);
+	_txtCloseHint = new Text(160, 96, 2, 102);
+	_txtTooltip = new Text(149, 44, 169, 154);
+
+	setInterface("diplomacyDialogue");
+
+	add(_bg);
+	add(_txtReply, "reply", "diplomacyDialogue");
+	add(_lstActions, "actions", "diplomacyDialogue");
+	add(_txtCloseHint, "reply", "diplomacyDialogue");
+	add(_txtTooltip, "tooltip", "diplomacyDialogue");
+
+	// Background
+	if (_faction && _faction->getRules())
+	{
+		auto rules = _faction->getRules();
+		std::string bgName = rules->getDiplomacyBackground();
+		if (bgName.empty())
+		{
+			bgName = rules->getBackground();
+		}
+		const auto* surf = _game->getMod()->getSurface(bgName);
+		if (surf)
+		{
+			surf->blitNShade(_bg, 0, 0);
+			if (isCpalSurfaceName(bgName))
+			{
+				setCustomPalette(surf->getPalette(), Mod::GEOSCAPE_CURSOR);
+				_bg->setPalette(_palette);
+				_txtReply->setPalette(_palette);
+				_lstActions->setPalette(_palette);
+				_txtTooltip->setPalette(_palette);
+			}
+		}
+	}
+
+	// Reply
+	_txtReply->setWordWrap(true);
+	_txtReply->setScrollable(true);
+
+	// Actions list
+	// Reserve some space for the built-in scrollbar/arrow buttons (they are drawn outside the list surface).
+	_lstActions->setColumns(1, 152); // 160 - 8 for scrollbar
+	_lstActions->setSelectable(true);
+	_lstActions->setBackground(_bg);
+	_lstActions->setMargin(2);
+	_lstActions->setWordWrap(true);
+	// Keep scroll controls in the gap between actions and tooltip.
+	_lstActions->setScrolling(true, -6);
+	_lstActions->setSelectorOffsetBlock(+12);
+	_lstActions->onMouseOver((ActionHandler)&DiplomacyDialogueState::lstActionsMouseOver);
+	_lstActions->onMouseOut((ActionHandler)&DiplomacyDialogueState::lstActionsMouseOut);
+	_lstActions->onMouseClick((ActionHandler)&DiplomacyDialogueState::lstActionsClick);
+
+	// Close hint (shown only in exit-mode)
+	_txtCloseHint->setWordWrap(true);
+	_txtCloseHint->setScrollable(false);
+	_txtCloseHint->setVisible(false);
+
+	// Tooltip
+	_txtTooltip->setWordWrap(true);
+	_txtTooltip->setScrollable(false);
+	_txtTooltip->setVerticalAlign(ALIGN_BOTTOM);
+
+	// Exit-mode click/any-key catcher (only closes when _exitMode is true)
+	_bg->onMouseClick((ActionHandler)&DiplomacyDialogueState::closeIfExitMode, SDL_BUTTON_LEFT);
+	_bg->onMouseClick((ActionHandler)&DiplomacyDialogueState::closeIfExitMode, SDL_BUTTON_RIGHT);
+	_bg->onKeyboardPress((ActionHandler)&DiplomacyDialogueState::closeIfExitMode);
+	_bg->setFocus(true);
+
+	setGreeting();
+	rebuildActionsList();
+	centerAllSurfaces();
+}
+
+DiplomacyDialogueState::~DiplomacyDialogueState() = default;
+
+void DiplomacyDialogueState::setGreeting()
+{
+	if (!_faction || !_faction->getRules())
+	{
+		_txtReply->setText("");
+		return;
+	}
+
+	const auto& greetings = _faction->getRules()->getGreetings();
+	int repLevel = _faction->getReputationLevel();
+	auto it = greetings.find(repLevel);
+	if (it == greetings.end() || it->second.empty())
+	{
+		// Fallback: try nearest lower rep level, else nearest higher.
+		auto lower = greetings.lower_bound(repLevel);
+		// lower_bound points to first element with key >= repLevel
+		if (lower != greetings.begin())
+		{
+			// Prefer the previous element (key < repLevel) if it exists.
+			--lower;
+			if (!lower->second.empty())
+			{
+				it = lower;
+			}
+		}
+
+		if (it == greetings.end() || it->second.empty())
+		{
+			// Otherwise try first element with key >= repLevel.
+			auto higher = greetings.lower_bound(repLevel);
+			if (higher != greetings.end() && !higher->second.empty())
+			{
+				it = higher;
+			}
+		}
+	}
+
+	if (it == greetings.end() || it->second.empty())
+	{
+		_txtReply->setText("");
+		return;
+	}
+
+	const auto& list = it->second;
+	const int idx = RNG::generate(0, static_cast<int>(list.size()) - 1);
+	_txtReply->setText(tr(list.at(static_cast<size_t>(idx))));
+}
+
+bool DiplomacyDialogueState::isActionAvailable(const RuleDiplomacyAction& action) const
+{
+	if (!_faction)
+	{
+		return false;
+	}
+	SavedGame* save = _game->getSavedGame();
+	if (!save)
+	{
+		return false;
+	}
+
+	const auto& cond = action.getConditions();
+
+	if (_faction->isActionOnCooldown(action.getType()))
+	{
+		Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: cooldown " << _faction->getActionCooldown(action.getType());
+		return false;
+	}
+
+	for (const auto& [factionName, minLvl] : cond.reputationLevelMin)
+	{
+		auto* f = findFactionByRules(*save, factionName);
+		if (!f || f->getReputationLevel() < minLvl)
+		{
+			Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: repLevelMin failed";
+			return false;
+		}
+	}
+	for (const auto& [factionName, maxLvl] : cond.reputationLevelMax)
+	{
+		auto* f = findFactionByRules(*save, factionName);
+		if (!f || f->getReputationLevel() >= maxLvl)
+		{
+			Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: repLevelMax failed";
+			return false;
+		}
+	}
+
+	if (cond.loyaltyMin && save->getLoyalty() < *cond.loyaltyMin)
+	{
+		Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: loyaltyMin";
+		return false;
+	}
+	if (cond.loyaltyMax && save->getLoyalty() >= *cond.loyaltyMax)
+	{
+		Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: loyaltyMax";
+		return false;
+	}
+
+	if (cond.fundsMin && save->getFunds() < *cond.fundsMin)
+	{
+		Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: fundsMin";
+		return false;
+	}
+	if (cond.fundsMax && save->getFunds() >= *cond.fundsMax)
+	{
+		Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: fundsMax";
+		return false;
+	}
+
+	for (const auto& [research, mustHave] : cond.researchTriggers)
+	{
+		bool has = save->isResearched(research);
+		if (mustHave != has)
+		{
+			Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: researchTrigger failed";
+			return false;
+		}
+	}
+
+	for (const auto& [item, mustHave] : cond.itemTriggers)
+	{
+		bool has = item ? save->isItemObtained(item->getType(), _game->getMod()) : false;
+		if (mustHave != has)
+		{
+			Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: itemTrigger failed";
+			return false;
+		}
+	}
+
+	for (const auto& [treatyId, mustHave] : cond.treaties)
+	{
+		bool has = _faction->hasTreaty(treatyId);
+		if (mustHave != has)
+		{
+			Log(LOG_DEBUG) << "DiplomacyAction " << action.getType() << " hidden: treaty failed for " << treatyId;
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void DiplomacyDialogueState::rebuildActionsList()
+{
+	// Normal mode: show options list, hide exit-mode hint.
+	if (_txtCloseHint)
+	{
+		_txtCloseHint->setVisible(false);
+	}
+	if (_lstActions)
+	{
+		_lstActions->setVisible(true);
+		_lstActions->setSelectable(true);
+	}
+
+	_visibleActions.clear();
+	_lstActions->clearList();
+	_txtTooltip->setText("");
+
+	if (!_faction || !_faction->getRules())
+	{
+		return;
+	}
+
+	const std::string& myFactionName = _faction->getRules()->getName();
+	auto* mod = _game->getMod();
+	if (!mod)
+	{
+		return;
+	}
+
+	auto list = mod->getDiplomacyActionList();
+	if (!list)
+	{
+		return;
+	}
+
+	std::vector<const RuleDiplomacyAction*> actions;
+	actions.reserve(list->size());
+
+	for (const auto& type : *list)
+	{
+		auto* action = mod->getDiplomacyAction(type);
+		if (!action)
+		{
+			continue;
+		}
+		if (action->getFactionRules() != _faction->getRules())
+		{
+			continue;
+		}
+		if (!isActionAvailable(*action))
+		{
+			continue;
+		}
+
+		actions.push_back(action);
+	}
+
+	std::stable_sort(actions.begin(), actions.end(),
+		[](const RuleDiplomacyAction* a, const RuleDiplomacyAction* b)
+		{
+			if (a == b)
+			{
+				return false;
+			}
+			const bool aExit = a && a->getEffects().specialNavigation == RuleDiplomacyAction::NAV_EXIT;
+			const bool bExit = b && b->getEffects().specialNavigation == RuleDiplomacyAction::NAV_EXIT;
+			if (aExit != bExit)
+			{
+				return !aExit; // EXIT always last
+			}
+			const int ao = a ? a->getListOrder() : 0;
+			const int bo = b ? b->getListOrder() : 0;
+			if (ao != bo)
+			{
+				return ao < bo;
+			}
+			// keep ruleset order for ties
+			return false;
+		});
+
+	_visibleActions = std::move(actions);
+	for (const auto* action : _visibleActions)
+	{
+		if (!action)
+		{
+			continue;
+		}
+		const std::string rowText = tr(action->getText());
+		_lstActions->addRow(1, const_cast<char*>(rowText.c_str()));
+	}
+
+	Log(LOG_DEBUG) << "DiplomacyDialogueState: visible actions for " << myFactionName << ": " << _visibleActions.size();
+}
+
+void DiplomacyDialogueState::applyAction(const RuleDiplomacyAction& action, Action* triggerAction)
+{
+	SavedGame* save = _game->getSavedGame();
+	auto* mod = _game->getMod();
+	auto* mind = _game->getMasterMind();
+	if (!save || !mod || !mind || !_faction)
+	{
+		return;
+	}
+
+	Log(LOG_DEBUG) << "DiplomacyDialogueState: applying action " << action.getType();
+
+	const auto& eff = action.getEffects();
+	const auto& cond = action.getConditions();
+
+	if (!eff.responseText.empty())
+	{
+		_txtReply->setText(tr(eff.responseText));
+	}
+
+	for (const auto& [factionRules, delta] : eff.reputationChanges)
+	{
+		auto* f = findFactionByRules(*save, factionRules);
+		if (!f)
+		{
+			Log(LOG_DEBUG) << "DiplomacyDialogueState: reputationChanges skipped, faction not found";
+			continue;
+		}
+		f->updateReputationScore(delta);
+		mind->updateReputationLvl(f, false);
+	}
+
+	if (!Mod::isEmptyRuleName(action.getEventScriptName()))
+	{
+		mind->eventScriptProcessor({action.getEventScriptName()}, OTHER_SCRIPT);
+	}
+
+	if (eff.funds)
+	{
+		save->setFunds(save->getFunds() + *eff.funds);
+	}
+
+	if (eff.loyalty)
+	{
+		save->setLoyalty(save->getLoyalty() + *eff.loyalty);
+	}
+
+	if (!Mod::isEmptyRuleName(action.getSpawnMissionName()))
+	{
+		GeoscapeState* gs = _game->getGeoscapeState();
+		Base* firstBase = (save->getBases() && !save->getBases()->empty()) ? save->getBases()->front() : nullptr;
+		if (gs && gs->getGlobe() && firstBase)
+		{
+			mind->spawnAlienMission(action.getSpawnMissionName(), *gs->getGlobe(), firstBase);
+		}
+		else
+		{
+			Log(LOG_DEBUG) << "DiplomacyDialogueState: spawnMission skipped (missing GeoscapeState/globe/base)";
+		}
+	}
+
+	for (const auto& [treatyId, enabled] : eff.changeTreaty)
+	{
+		_faction->setTreaty(treatyId, enabled);
+	}
+
+	if (cond.timerCooldown && *cond.timerCooldown > 0)
+	{
+		_faction->setActionCooldown(action.getType(), *cond.timerCooldown);
+	}
+
+	switch (eff.specialNavigation)
+	{
+	case RuleDiplomacyAction::NAV_EXIT:
+		_exitMode = true;
+		_exitModeIgnoreEvent = triggerAction ? triggerAction->getDetails() : nullptr;
+		_lstActions->setVisible(false);
+		_lstActions->setSelectable(false);
+		_txtCloseHint->setText(tr("STR_DIPLOMACY_TALK_CLOSE"));
+		_txtCloseHint->setVisible(true);
+		_txtTooltip->setText("");
+		return;
+	case RuleDiplomacyAction::NAV_HIRE_SOLDIERS:
+		if (_base != 0)
+		{
+			_game->pushState(new DiplomacyHirePersonnelState(_base, _faction));
+		}
+		else if (_game->getSavedGame()->getBases()->size() == 1)
+		{
+			_game->pushState(new DiplomacyHirePersonnelState(_game->getSavedGame()->getBases()->front(), _faction));
+		}
+		else
+		{
+			_game->pushState(new DiplomacyChooseBaseState(_faction, OPERATION_HIRING));
+		}
+		break;
+	case RuleDiplomacyAction::NAV_NONE:
+	default:
+		break;
+	}
+
+	rebuildActionsList();
+}
+
+void DiplomacyDialogueState::closeIfExitMode(Action* action)
+{
+	if (_exitMode)
+	{
+		if (_exitModeIgnoreEvent && action && action->getDetails() == _exitModeIgnoreEvent)
+		{
+			// Ignore the same click/keypress that switched us into exit mode.
+			_exitModeIgnoreEvent = nullptr;
+			return;
+		}
+		_game->popState();
+	}
+}
+
+void DiplomacyDialogueState::lstActionsMouseOver(Action*)
+{
+	if (_exitMode)
+	{
+		return;
+	}
+	unsigned int row = _lstActions->getSelectedRow();
+	if (row < _visibleActions.size())
+	{
+		const auto* action = _visibleActions.at(row);
+		_txtTooltip->setText(tr(action->getTooltip()));
+	}
+	else
+	{
+		_txtTooltip->setText("");
+	}
+}
+
+void DiplomacyDialogueState::lstActionsMouseOut(Action*)
+{
+	if (_exitMode)
+	{
+		return;
+	}
+	_txtTooltip->setText("");
+}
+
+void DiplomacyDialogueState::lstActionsClick(Action* action)
+{
+	if (_exitMode)
+	{
+		return;
+	}
+
+	unsigned int row = _lstActions->getSelectedRow();
+	if (row < _visibleActions.size())
+	{
+		applyAction(*_visibleActions.at(row), action);
+	}
+}
+
+}

--- a/src/FTA/DiplomacyDialogueState.h
+++ b/src/FTA/DiplomacyDialogueState.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+ * Copyright 2010-2026 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "../Engine/State.h"
+
+#include <SDL.h>
+
+namespace OpenXcom
+{
+
+class Base;
+class DiplomacyFaction;
+class InteractiveSurface;
+class Text;
+class TextList;
+class RuleDiplomacyAction;
+
+class DiplomacyDialogueState : public State
+{
+private:
+	Base* _base;
+	DiplomacyFaction* _faction;
+
+	InteractiveSurface* _bg;
+	Text* _txtReply;
+	TextList* _lstActions;
+	Text* _txtCloseHint;
+	Text* _txtTooltip;
+
+	std::vector<const RuleDiplomacyAction*> _visibleActions;
+	bool _exitMode;
+	SDL_Event* _exitModeIgnoreEvent;
+
+	void setGreeting();
+	void rebuildActionsList();
+	bool isActionAvailable(const RuleDiplomacyAction& action) const;
+	void applyAction(const RuleDiplomacyAction& action, Action* triggerAction);
+
+	void closeIfExitMode(Action* action);
+	void lstActionsMouseOver(Action* action);
+	void lstActionsMouseOut(Action* action);
+	void lstActionsClick(Action* action);
+
+public:
+	DiplomacyDialogueState(Base* base, DiplomacyFaction* faction);
+	~DiplomacyDialogueState() override;
+};
+
+}

--- a/src/FTA/DiplomacyStartState.cpp
+++ b/src/FTA/DiplomacyStartState.cpp
@@ -32,6 +32,7 @@
 #include "../FTA/DiplomacySellState.h"
 #include "../FTA/DiplomacyPurchaseState.h"
 #include "../FTA/DiplomacyHirePersonnelState.h"
+#include "../FTA/DiplomacyDialogueState.h"
 
 namespace OpenXcom
 {
@@ -64,7 +65,9 @@ DiplomacyStartState::DiplomacyStartState(Base* base, bool geoscape) : _base(base
 	int dX = 103;
 	for (std::vector<DiplomacyFaction*>::iterator i = factions.begin(); i != factions.end(); ++i)
 	{
-		if (step > 2) { break; } //draw only 3 cards
+		if (step == 3)
+			break;	//draw only 3 cards
+
 		dX *= step;
 		faction = factions.at(step);
 		Window* card = new Window(this, 98, 150, 8 + dX, 25, POPUP_NONE);
@@ -179,18 +182,7 @@ void DiplomacyStartState::btnTalkClick(Action* action)
 			auto faction = _game->getSavedGame()->getDiplomacyFactions().at(i);
 			if (faction)
 			{
-				if (_base != 0)
-				{
-					_game->pushState(new DiplomacyHirePersonnelState(_base, faction));
-				}
-				else if (_game->getSavedGame()->getBases()->size() == 1)
-				{
-					_game->pushState(new DiplomacyHirePersonnelState(_game->getSavedGame()->getBases()->front(), faction));
-				}
-				else
-				{
-					_game->pushState(new DiplomacyChooseBaseState(faction, OPERATION_HIRING));
-				}
+				_game->pushState(new DiplomacyDialogueState(_base, faction));
 			}
 
 			break;
@@ -314,7 +306,7 @@ DiplomacyInfoState::DiplomacyInfoState(const DiplomacyFaction* faction)
 	_btnOk->onMouseClick((ActionHandler)&DiplomacyInfoState::btnOkClick);
 	_btnOk->onKeyboardPress((ActionHandler)&DiplomacyInfoState::btnOkClick, Options::keyOk);
 	_btnOk->onKeyboardPress((ActionHandler)&DiplomacyInfoState::btnOkClick, Options::keyCancel);
-	
+
 }
 
 DiplomacyInfoState::~DiplomacyInfoState()
@@ -333,7 +325,7 @@ DiplomacyChooseBaseState::DiplomacyChooseBaseState(DiplomacyFaction* faction, Tr
 {
 	_screen = false;
 	std::string interfaceName = "diplomacyMainWindow";
-	
+
 	setInterface(interfaceName);
 	int bCount = _game->getSavedGame()->getBases()->size();
 	int btnH = 17;

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1905,6 +1905,12 @@ bool GeoscapeState::processMissionSite(MissionSite *site)
  */
 void GeoscapeState::time30Minutes()
 {
+	// Tick diplomacy dialogue action cooldowns
+	for (auto* faction : _game->getSavedGame()->getDiplomacyFactions())
+	{
+		faction->tickActionCooldowns(30);
+	}
+
 	// Decrease mission countdowns
 	for (auto* am : _game->getSavedGame()->getAlienMissions())
 	{

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -44,7 +44,7 @@ TextList::TextList(int width, int height, int x, int y) : InteractiveSurface(wid
 	_dot(false), _selectable(false), _condensed(false), _contrast(false), _wrap(false), _flooding(false), _ignoreSeparators(false),
 	_bg(0), _selector(0), _margin(0), _scrolling(true), _arrowPos(-1), _scrollPos(3), _arrowType(ARROW_VERTICAL),
 	_leftClick(0), _leftPress(0), _leftRelease(0), _rightClick(0), _rightPress(0), _rightRelease(0),
-	_arrowsLeftEdge(0), _arrowsRightEdge(0), _noScrollLeftEdge(0), _noScrollRightEdge(0), _comboBox(0)
+	_arrowsLeftEdge(0), _arrowsRightEdge(0), _noScrollLeftEdge(0), _noScrollRightEdge(0), _comboBox(0), _selectorOffsetBlock(-10)
 {
 	_up = new ArrowButton(ARROW_BIG_UP, 13, 14, getX() + getWidth() + _scrollPos, getY());
 	_up->setVisible(false);
@@ -1292,7 +1292,7 @@ void TextList::mouseOver(Action *action, State *state)
 			}
 			else
 			{
-				_selector->offsetBlock(-10);
+				_selector->offsetBlock(_selectorOffsetBlock);
 			}
 			_selector->setVisible(true);
 		}
@@ -1303,6 +1303,11 @@ void TextList::mouseOver(Action *action, State *state)
 	}
 
 	InteractiveSurface::mouseOver(action, state);
+}
+
+void TextList::setSelectorOffsetBlock(int off)
+{
+	_selectorOffsetBlock = off;
 }
 
 /**

--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -60,6 +60,7 @@ private:
 	int _arrowsLeftEdge, _arrowsRightEdge;
 	int _noScrollLeftEdge, _noScrollRightEdge;
 	ComboBox *_comboBox;
+	int _selectorOffsetBlock;
 
 	/// Updates the arrow buttons.
 	void updateArrows();
@@ -128,6 +129,8 @@ public:
 	void setWordWrap(bool wrap);
 	/// Sets the text list's high contrast color setting.
 	void setHighContrast(bool contrast) override;
+	/// Sets how much the hover selector shifts background colors (block-based).
+	void setSelectorOffsetBlock(int off);
 	/// Sets the text horizontal alignment of the text list.
 	void setAlign(TextHAlign align, int col = -1);
 	/// Sets whether to separate columns with dots.

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -85,6 +85,7 @@
 #include "RuleInterface.h"
 #include "RuleDiplomacyFaction.h"
 #include "RuleDiplomacyFactionEvent.h"
+#include "RuleDiplomacyAction.h"
 #include "RuleCovertOperation.h"
 #include "RuleObject.h"
 #include "RuleArcScript.h"
@@ -825,6 +826,10 @@ Mod::~Mod()
 	}
 
 	for (auto& pair : _diplomacyFactionEvents)
+	{
+		delete pair.second;
+	}
+	for (auto& pair : _diplomacyActions)
 	{
 		delete pair.second;
 	}
@@ -2368,6 +2373,7 @@ void Mod::loadAll()
 	afterLoadHelper("countries", this, _countries, &RuleCountry::afterLoad);
 	afterLoadHelper("crafts", this, _crafts, &RuleCraft::afterLoad);
 	afterLoadHelper("events", this, _events, &RuleEvent::afterLoad);
+	afterLoadHelper("diplomacyActions", this, _diplomacyActions, &RuleDiplomacyAction::afterLoad);
 
 	for (auto& a : _armors)
 	{
@@ -3122,6 +3128,14 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 	for (const auto& ruleReader : iterateRules("diplomacyFactionEvents", "type"))
 	{
 		RuleDiplomacyFactionEvent* rule = loadRule(ruleReader, &_diplomacyFactionEvents, &_diplomacyFactionEventIndex, "type");
+		if (rule != 0)
+		{
+			rule->load(ruleReader);
+		}
+	}
+	for (const auto& ruleReader : iterateRules("diplomacyActions", "type"))
+	{
+		RuleDiplomacyAction* rule = loadRule(ruleReader, &_diplomacyActions, &_diplomacyActionIndex, "type");
 		if (rule != 0)
 		{
 			rule->load(ruleReader);
@@ -5444,6 +5458,11 @@ RuleDiplomacyFactionEvent* Mod::getDiplomacyFactionEvent(const std::string& name
 	return getRule(name, "Diplomacy Faction Event", _diplomacyFactionEvents, error);
 }
 
+RuleDiplomacyAction* Mod::getDiplomacyAction(const std::string& type, bool error) const
+{
+	return getRule(type, "Diplomacy Action", _diplomacyActions, error);
+}
+
 RuleObject* Mod::getObject(const std::string& type, bool error) const
 {
 	return getRule(type, "Rule Object", _objects, error);
@@ -5457,6 +5476,11 @@ const std::vector<std::string>* Mod::getDiplomacyFactionList() const
 const std::vector<std::string>* Mod::getDiplomacyFactionEventList() const
 {
 	return &_diplomacyFactionEventIndex;
+}
+
+const std::vector<std::string>* Mod::getDiplomacyActionList() const
+{
+	return &_diplomacyActionIndex;
 }
 
 RuleCovertOperation* Mod::getCovertOperation(const std::string& name, bool error) const

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -101,6 +101,7 @@ class RuleVideo;
 class RuleMusic;
 class RuleDiplomacyFaction;
 class RuleDiplomacyFactionEvent;
+class RuleDiplomacyAction;
 class RuleCovertOperation;
 class RuleObject;
 class RuleArcScript;
@@ -214,6 +215,7 @@ private:
 	std::map<std::string, RuleCommendations *> _commendations;
 	std::map<std::string, RuleDiplomacyFaction*> _diplomacyFactions;
 	std::map<std::string, RuleDiplomacyFactionEvent*> _diplomacyFactionEvents;
+	std::map<std::string, RuleDiplomacyAction*> _diplomacyActions;
 	std::map<std::string, RuleCovertOperation*> _covertOperations;
 	std::map<std::string, RuleObject*> _objects;
 	std::map<std::string, RuleArcScript*> _arcScripts;
@@ -344,7 +346,7 @@ private:
 	std::vector<std::string> _aliensIndex, _enviroEffectsIndex, _startingConditionsIndex, _deploymentsIndex, _armorsIndex, _ufopaediaIndex, _ufopaediaCatIndex, _researchIndex, _manufactureIndex, _intelligenceIndex, _prisonerIndex;
 	std::vector<std::string> _skillsIndex, _soldiersIndex, _soldierTransformationIndex, _soldierBonusIndex;
 	std::vector<std::string> _alienMissionsIndex, _terrainIndex, _customPalettesIndex, _arcScriptIndex, _eventScriptIndex, _eventIndex, _missionScriptIndex, _adhocScriptIndex;
-	std::vector<std::string> _diplomacyFactionIndex, _diplomacyFactionEventIndex, _covertOperationIndex, _objectIndex;
+	std::vector<std::string> _diplomacyFactionIndex, _diplomacyFactionEventIndex, _diplomacyActionIndex, _covertOperationIndex, _objectIndex;
 	std::vector<std::vector<int> > _alienItemLevels;
 	std::vector<std::array<SDL_Color, TransparenciesOpacityLevels>> _transparencies;
 	int _facilityListOrder, _craftListOrder, _covertOperationListOrder, _itemCategoryListOrder, _itemListOrder, _armorListOrder;
@@ -963,7 +965,7 @@ public:
 	bool isFTAGame() const { return _ftaGame; }
 	/// Gets lenght of FtA game (while in alpha) in months
 	int getFTAGameLength() const { return _ftaGameLength; }
-	
+
 	/// Gets if ironman enabled in a ruleset.
 	bool getIsIronManEnabled() const { return _ironManEnabled; }
 	/// Gets if research tree was disabled.
@@ -1203,12 +1205,15 @@ public:
 	RuleDiplomacyFaction* getDiplomacyFaction(const std::string& name, bool error = false) const;
 	/// Gets Diplomacy Factions Event rules for FTA game
 	RuleDiplomacyFactionEvent* getDiplomacyFactionEvent(const std::string& name, bool error = false) const;
+	/// Gets Diplomacy Action rules for FTA game
+	RuleDiplomacyAction* getDiplomacyAction(const std::string& type, bool error = false) const;
 	/// Gets Covert Operation rules for FTA game
 	RuleCovertOperation* getCovertOperation(const std::string& name, bool error = false) const;
 	/// Gets Object rules for FTA game
 	RuleObject* getObject(const std::string& type, bool error = false) const;
 	const std::vector<std::string>* getDiplomacyFactionList() const;
 	const std::vector<std::string>* getDiplomacyFactionEventList() const;
+	const std::vector<std::string>* getDiplomacyActionList() const;
 	const std::vector<std::string>* getCovertOperationList() const;
 	const std::vector<std::string>* getArcScriptList() const;
 	RuleArcScript* getArcScript(const std::string& name, bool error = false) const;
@@ -1235,7 +1240,7 @@ public:
 	int getLoyaltyCoefAlienBase() const { return _coefAlienBase; }
 	int getLoyaltyNoFundsPenalty() const { return _noFundsPenalty; }
 	int getLoyaltyNoFundsValue() const { return _noFundsValue; }
-	
+
 	RuleMissionScript *getAdhocScript(const std::string &name, bool error = false) const;
 	/// Get global script data.
 	ScriptGlobal *getScriptGlobal() const;

--- a/src/Mod/RuleDiplomacyAction.cpp
+++ b/src/Mod/RuleDiplomacyAction.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2010-2026 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "RuleDiplomacyAction.h"
+#include "Mod.h"
+
+
+namespace OpenXcom
+{
+
+namespace
+{
+	static void readFactionLevelMap(const YAML::YamlNodeReader& node, std::map<std::string, int>& out)
+	{
+		if (!node)
+		{
+			return;
+		}
+
+		if (node.isMap())
+		{
+			for (const auto& child : node.children())
+			{
+				std::string key;
+				int value = 0;
+				if (child.tryReadKey(key) && child.tryReadVal(value))
+				{
+					out[key] = value;
+				}
+			}
+			return;
+		}
+
+		if (node.isSeq())
+		{
+			for (const auto& entry : node.children())
+			{
+				if (!entry.isMap())
+				{
+					continue;
+				}
+				for (const auto& child : entry.children())
+				{
+					std::string key;
+					int value = 0;
+					if (child.tryReadKey(key) && child.tryReadVal(value))
+					{
+						out[key] = value;
+					}
+				}
+			}
+		}
+	}
+
+	static RuleDiplomacyAction::SpecialNavigation parseNavigation(const std::string& s)
+	{
+		if (s == "EXIT")
+		{
+			return RuleDiplomacyAction::NAV_EXIT;
+		}
+		if (s == "HIRE_SOLDIERS")
+		{
+			return RuleDiplomacyAction::NAV_HIRE_SOLDIERS;
+		}
+		return RuleDiplomacyAction::NAV_NONE;
+	}
+
+} // namespace
+
+
+RuleDiplomacyAction::RuleDiplomacyAction(const std::string& type)
+	: _type(type)
+{
+}
+
+void RuleDiplomacyAction::load(const YAML::YamlNodeReader& node)
+{
+	const auto& reader = node.useIndex();
+	if (const YAML::YamlNodeReader& parent = reader["refNode"])
+	{
+		load(reader["refNode"]);
+	}
+
+	reader.tryRead("type", _type);
+	reader.tryRead("listOrder", _listOrder);
+	reader.tryRead("faction", _factionName);
+	reader.tryRead("text", _text);
+	reader.tryRead("tooltip", _tooltip);
+
+	if (const YAML::YamlNodeReader& conditions = reader["conditions"])
+	{
+		const auto& c = conditions.useIndex();
+
+		readFactionLevelMap(c["reputationLevelMin"], _reputationLevelMinNames);
+		readFactionLevelMap(c["reputationLevelMax"], _reputationLevelMaxNames);
+
+		int loyaltyMin = 0;
+		if (c.tryRead("loyaltyMin", loyaltyMin))
+		{
+			_conditions.loyaltyMin = loyaltyMin;
+		}
+		int loyaltyMax = 0;
+		if (c.tryRead("loyaltyMax", loyaltyMax))
+		{
+			_conditions.loyaltyMax = loyaltyMax;
+		}
+		int64_t fundsMin = 0;
+		if (c.tryRead("fundsMin", fundsMin))
+		{
+			_conditions.fundsMin = fundsMin;
+		}
+		int64_t fundsMax = 0;
+		if (c.tryRead("fundsMax", fundsMax))
+		{
+			_conditions.fundsMax = fundsMax;
+		}
+
+		c.tryRead("researchTriggers", _researchTriggerNames);
+		c.tryRead("itemTriggers", _itemTriggerNames);
+		c.tryRead("treaties", _conditions.treaties);
+
+		int timerCooldown = 0;
+		if (c.tryRead("timerCooldown", timerCooldown))
+		{
+			_conditions.timerCooldown = timerCooldown;
+		}
+	}
+
+	if (const YAML::YamlNodeReader& effects = reader["effects"])
+	{
+		const auto& e = effects.useIndex();
+		e.tryRead("responseText", _effects.responseText);
+		e.tryRead("reputationChanges", _reputationChangeNames);
+		e.tryRead("eventScript", _eventScriptName);
+
+		int64_t funds = 0;
+		if (e.tryRead("funds", funds))
+		{
+			_effects.funds = funds;
+		}
+
+		int loyalty = 0;
+		if (e.tryRead("loyalty", loyalty))
+		{
+			_effects.loyalty = loyalty;
+		}
+
+		e.tryRead("spawnMission", _spawnMissionName);
+		e.tryRead("changeTreaty", _effects.changeTreaty);
+
+		std::string nav;
+		if (e.tryRead("specialNavigation", nav))
+		{
+			_effects.specialNavigation = parseNavigation(nav);
+		}
+	}
+}
+
+void RuleDiplomacyAction::afterLoad(const Mod* mod)
+{
+	if (!mod)
+	{
+		return;
+	}
+
+	_faction = mod->getDiplomacyFaction(_factionName, true);
+
+	_conditions.reputationLevelMin.clear();
+	_conditions.reputationLevelMax.clear();
+	_conditions.researchTriggers.clear();
+	_conditions.itemTriggers.clear();
+	_effects.reputationChanges.clear();
+	_effects.eventScript = nullptr;
+	_effects.spawnMission = nullptr;
+
+	for (const auto& [factionName, lvl] : _reputationLevelMinNames)
+	{
+		_conditions.reputationLevelMin[mod->getDiplomacyFaction(factionName, true)] = lvl;
+	}
+	for (const auto& [factionName, lvl] : _reputationLevelMaxNames)
+	{
+		_conditions.reputationLevelMax[mod->getDiplomacyFaction(factionName, true)] = lvl;
+	}
+	for (const auto& [researchName, mustHave] : _researchTriggerNames)
+	{
+		_conditions.researchTriggers[mod->getResearch(researchName, true)] = mustHave;
+	}
+	for (const auto& [itemName, mustHave] : _itemTriggerNames)
+	{
+		_conditions.itemTriggers[mod->getItem(itemName, true)] = mustHave;
+	}
+
+	for (const auto& [factionName, delta] : _reputationChangeNames)
+	{
+		_effects.reputationChanges[mod->getDiplomacyFaction(factionName, true)] = delta;
+	}
+
+	if (!Mod::isEmptyRuleName(_eventScriptName))
+	{
+		_effects.eventScript = mod->getEventScript(_eventScriptName, true);
+	}
+	if (!Mod::isEmptyRuleName(_spawnMissionName))
+	{
+		_effects.spawnMission = mod->getAlienMission(_spawnMissionName, true);
+	}
+}
+
+}

--- a/src/Mod/RuleDiplomacyAction.h
+++ b/src/Mod/RuleDiplomacyAction.h
@@ -1,0 +1,108 @@
+#pragma once
+/*
+ * Copyright 2010-2026 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <string>
+#include <map>
+#include <optional>
+#include "../Engine/Yaml.h"
+
+namespace OpenXcom
+{
+
+class Mod;
+class RuleAlienMission;
+class RuleDiplomacyFaction;
+class RuleEventScript;
+class RuleItem;
+class RuleResearch;
+
+class RuleDiplomacyAction
+{
+public:
+	enum SpecialNavigation
+	{
+		NAV_NONE,
+		NAV_EXIT,
+		NAV_HIRE_SOLDIERS
+	};
+
+	struct Conditions
+	{
+		std::map<const RuleDiplomacyFaction*, int> reputationLevelMin;
+		std::map<const RuleDiplomacyFaction*, int> reputationLevelMax;
+		std::optional<int> loyaltyMin;
+		std::optional<int> loyaltyMax;
+		std::optional<int64_t> fundsMin;
+		std::optional<int64_t> fundsMax;
+		std::map<const RuleResearch*, bool> researchTriggers;
+		std::map<const RuleItem*, bool> itemTriggers;
+		std::map<std::string, bool> treaties;
+		std::optional<int> timerCooldown;
+	};
+
+	struct Effects
+	{
+		std::string responseText;
+		std::map<const RuleDiplomacyFaction*, int> reputationChanges;
+		const RuleEventScript* eventScript = nullptr;
+		std::optional<int64_t> funds;
+		std::optional<int> loyalty;
+		const RuleAlienMission* spawnMission = nullptr;
+		std::map<std::string, bool> changeTreaty;
+		SpecialNavigation specialNavigation = NAV_NONE;
+	};
+
+private:
+	std::string _type;
+	int _listOrder = 0;
+	std::string _factionName;
+	const RuleDiplomacyFaction* _faction = nullptr;
+	std::string _text;
+	std::string _tooltip;
+	Conditions _conditions;
+	Effects _effects;
+
+	std::map<std::string, int> _reputationLevelMinNames;
+	typedef std::map<std::string, int> StringIntMap;
+	StringIntMap _reputationLevelMaxNames;
+	std::map<std::string, bool> _researchTriggerNames;
+	std::map<std::string, bool> _itemTriggerNames;
+	StringIntMap _reputationChangeNames;
+	std::string _eventScriptName;
+	std::string _spawnMissionName;
+
+public:
+	RuleDiplomacyAction(const std::string& type);
+	~RuleDiplomacyAction() = default;
+
+	void load(const YAML::YamlNodeReader& reader);
+	void afterLoad(const Mod* mod);
+
+	const std::string& getType() const { return _type; }
+	int getListOrder() const { return _listOrder; }
+	const RuleDiplomacyFaction* getFactionRules() const { return _faction; }
+	const std::string& getEventScriptName() const { return _eventScriptName; }
+	const std::string& getSpawnMissionName() const { return _spawnMissionName; }
+	const std::string& getText() const { return _text; }
+	const std::string& getTooltip() const { return _tooltip; }
+	const Conditions& getConditions() const { return _conditions; }
+	const Effects& getEffects() const { return _effects; }
+};
+
+}

--- a/src/Mod/RuleDiplomacyFaction.cpp
+++ b/src/Mod/RuleDiplomacyFaction.cpp
@@ -23,8 +23,54 @@
 namespace OpenXcom
 {
 
+namespace
+{
+	static void readGreetings(const YAML::YamlNodeReader& node, std::map<int, std::vector<std::string>>& inout)
+	{
+		if (!node || !node.isMap())
+		{
+			return;
+		}
+
+		for (const auto& entry : node.children())
+		{
+			int repLevel = 0;
+			if (!entry.tryReadKey(repLevel))
+			{
+				continue;
+			}
+
+			std::vector<std::string> values;
+			if (entry.isSeq())
+			{
+				for (const auto& v : entry.children())
+				{
+					std::string s;
+					if (v.tryReadVal(s) && !s.empty())
+					{
+						values.push_back(std::move(s));
+					}
+				}
+			}
+			else
+			{
+				std::string s;
+				if (entry.tryReadVal(s) && !s.empty())
+				{
+					values.push_back(std::move(s));
+				}
+			}
+
+			if (!values.empty())
+			{
+				inout[repLevel] = std::move(values);
+			}
+		}
+	}
+}
+
 RuleDiplomacyFaction::RuleDiplomacyFaction(const std::string &name) :
-	_name(name), _description("NONE"), _background("BACK13.SCR"), _cardBackground("BACK13.SCR"),
+	_name(name), _description("NONE"), _background("BACK13.SCR"), _cardBackground("BACK13.SCR"), _diplomacyBackground("BACK13.SCR"),
 	_genMissionFrequency(0), _helpTreatyGap(0),
 	_sellPriceFactor(0), _buyPriceFactor(0), _repPriceFactor(0), _powerHungry(10000), _scienceBaseCost(2000),
 	_startingReputation(0), _startingFunds(0), _startingPower(0)
@@ -42,6 +88,11 @@ void RuleDiplomacyFaction::load(const YAML::YamlNodeReader& node)
 	reader.tryRead("description", _description);
 	reader.tryRead("background", _background);
 	reader.tryRead("cardBackground", _cardBackground);
+	reader.tryRead("diplomacyBackground", _diplomacyBackground);
+	if (const YAML::YamlNodeReader& greetings = reader["greetings"])
+	{
+		readGreetings(greetings, _greetings);
+	}
 	reader.tryRead("discoverResearch", _discoverResearch);
 	reader.tryRead("discoverEvent", _discoverEvent);
 	reader.tryRead("helpTreatyMissions", _helpTreatyMissions);

--- a/src/Mod/RuleDiplomacyFaction.h
+++ b/src/Mod/RuleDiplomacyFaction.h
@@ -32,12 +32,13 @@ namespace OpenXcom
 class RuleDiplomacyFaction
 {
 private:
-	std::string _name, _description, _background, _cardBackground, _discoverResearch, _discoverEvent, _startingResearch;
+	std::string _name, _description, _background, _cardBackground, _diplomacyBackground, _discoverResearch, _discoverEvent, _startingResearch;
 	int _genMissionFrequency, _helpTreatyGap;
 	int _sellPriceFactor, _buyPriceFactor, _repPriceFactor, _powerHungry, _scienceBaseCost;
 	int _startingReputation, _startingFunds, _startingPower;
 	std::map<std::string, int> _startingItems, _startingStaff, _staffWeights;
 	std::map<std::string, double> _wishList;
+	std::map<int, std::vector<std::string>> _greetings;
 	std::vector<std::string> _helpTreatyMissions, _helpTreatyEventScripts, _usualEventsScripts, _happyEvents, _angryEvents, _startingResearches, _factionalEvents;
 public:
 	/// Creates a blank RuleDiplomacyFaction.
@@ -54,6 +55,10 @@ public:
 	const std::string &getBackground() const { return _background; }
 	/// Gets the sprite name, that uses to render diplomacy card.
 	const std::string &getCardBackground() const { return _cardBackground; }
+	/// Gets the diplomacy dialogue background image.
+	const std::string& getDiplomacyBackground() const { return _diplomacyBackground; }
+	/// Gets the greeting strings indexed by reputation level.
+	const std::map<int, std::vector<std::string>>& getGreetings() const { return _greetings; }
 
 	/// Gets the reseach name, that opens the Faction.
 	const std::string& getDiscoverResearch() const { return _discoverResearch; }

--- a/src/OpenXcom.2010.vcxproj
+++ b/src/OpenXcom.2010.vcxproj
@@ -550,6 +550,7 @@
     <ClCompile Include="Engine\Unicode.cpp" />
     <ClCompile Include="Engine\Yaml.cpp" />
     <ClCompile Include="Engine\Zoom.cpp" />
+    <ClCompile Include="FTA\DiplomacyDialogueState.cpp" />
     <ClCompile Include="FTA\DiplomacyHirePersonnelState.cpp" />
     <ClCompile Include="FTA\DiplomacyPurchaseState.cpp" />
     <ClCompile Include="FTA\DiplomacySellState.cpp" />
@@ -680,6 +681,7 @@
     <ClCompile Include="Mod\RuleEventScript.cpp" />
     <ClCompile Include="Mod\RuleIntelProject.cpp" />
     <ClCompile Include="Mod\RuleItemCategory.cpp" />
+    <ClCompile Include="Mod\RuleDiplomacyAction.cpp" />
     <ClCompile Include="Mod\RuleManufactureShortcut.cpp" />
     <ClCompile Include="Mod\RuleObject.cpp" />
     <ClCompile Include="Mod\RulePrisoner.cpp" />
@@ -1099,6 +1101,7 @@
     <ClInclude Include="Engine\Zoom.h" />
     <ClInclude Include="fallthrough.h" />
     <ClInclude Include="fmath.h" />
+    <ClInclude Include="FTA\DiplomacyDialogueState.h" />
     <ClInclude Include="FTA\DiplomacyHirePersonnelState.h" />
     <ClInclude Include="FTA\DiplomacyPurchaseState.h" />
     <ClInclude Include="FTA\DiplomacySellState.h" />
@@ -1224,6 +1227,7 @@
     <ClInclude Include="Mod\RuleBaseFacilityFunctions.h" />
     <ClInclude Include="Mod\RuleCovertOperation.h" />
     <ClInclude Include="Mod\RuleDamageType.h" />
+    <ClInclude Include="Mod\RuleDiplomacyAction.h" />
     <ClInclude Include="Mod\RuleDiplomacyFaction.h" />
     <ClInclude Include="Mod\RuleDiplomacyFactionEvent.h" />
     <ClInclude Include="Mod\RuleEnviroEffects.h" />

--- a/src/OpenXcom.2010.vcxproj.filters
+++ b/src/OpenXcom.2010.vcxproj.filters
@@ -1136,6 +1136,9 @@
     <ClCompile Include="Mod\RuleDiplomacyFaction.cpp">
       <Filter>Mod</Filter>
     </ClCompile>
+    <ClCompile Include="Mod\RuleDiplomacyAction.cpp">
+      <Filter>Mod</Filter>
+    </ClCompile>
     <ClCompile Include="Savegame\DiplomacyFaction.cpp">
       <Filter>Savegame</Filter>
     </ClCompile>
@@ -1408,6 +1411,9 @@
     </ClCompile>
     <ClCompile Include="Basescape\ItemLocationsState.cpp">
       <Filter>Basescape</Filter>
+    </ClCompile>
+    <ClCompile Include="FTA\DiplomacyDialogueState.cpp">
+      <Filter>FTA</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1818,9 +1824,6 @@
       <Filter>Engine</Filter>
     </ClInclude>
     <ClInclude Include="Engine\OXCCrypto.h">
-      <Filter>Engine</Filter>
-    </ClInclude>
-    <ClInclude Include="Engine\tiny_aes.h">
       <Filter>Engine</Filter>
     </ClInclude>
     <ClInclude Include="Battlescape\ActionMenuState.h">
@@ -2606,6 +2609,9 @@
     <ClInclude Include="Mod\RuleDiplomacyFaction.h">
       <Filter>Mod</Filter>
     </ClInclude>
+    <ClInclude Include="Mod\RuleDiplomacyAction.h">
+      <Filter>Mod</Filter>
+    </ClInclude>
     <ClInclude Include="Savegame\DiplomacyFaction.h">
       <Filter>Savegame</Filter>
     </ClInclude>
@@ -3073,6 +3079,9 @@
     </ClInclude>
     <ClInclude Include="Engine\NullableValue.h">
       <Filter>Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="FTA\DiplomacyDialogueState.h">
+      <Filter>FTA</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Savegame/DiplomacyFaction.cpp
+++ b/src/Savegame/DiplomacyFaction.cpp
@@ -74,6 +74,7 @@ void DiplomacyFaction::load(const YAML::YamlNodeReader &reader, SavedGame *save)
 	reader.tryRead("discovered", _discovered);
 	reader.tryRead("thisMonthDiscovered", _thisMonthDiscovered);
 	reader.tryRead("treaties", _treaties);
+	reader.tryRead("actionCooldowns", _actionCooldowns);
 	reader.tryRead("unlockedResearches", _unlockedResearches);
 	_items->load(reader["items"], _mod);
 	for (const auto& researchReader : reader["research"].children())
@@ -125,6 +126,10 @@ void DiplomacyFaction::save(YAML::YamlNodeWriter writer) const
 		writer.write("thisMonthDiscovered", _thisMonthDiscovered);
 	}
 	writer.write("treaties", _treaties);
+	if (!_actionCooldowns.empty())
+	{
+		writer.write("actionCooldowns", _actionCooldowns);
+	}
 	writer.write("unlockedResearches", _unlockedResearches);
 	_items->save(writer["items"]);
 	_staffPool->save(writer["soldierPool"], _mod);
@@ -136,6 +141,112 @@ void DiplomacyFaction::save(YAML::YamlNodeWriter writer) const
 		}
 	);
 	writer.write("dailyRepScore", _dailyRepScore);
+}
+
+bool DiplomacyFaction::hasTreaty(const std::string& treatyId) const
+{
+	return std::find(_treaties.begin(), _treaties.end(), treatyId) != _treaties.end();
+}
+
+namespace
+{
+	static const char* treatyToId(TreatyName treaty)
+	{
+		switch (treaty)
+		{
+		case HELP_TREATY:
+			return "HELP_TREATY";
+		case RESEARCH_TREATY:
+			return "RESEARCH_TREATY";
+		default:
+			return "";
+		}
+	}
+}
+
+bool DiplomacyFaction::hasTreaty(TreatyName treaty) const
+{
+	const char* id = treatyToId(treaty);
+	if (!id || !*id)
+	{
+		return false;
+	}
+	return hasTreaty(std::string{id});
+}
+
+void DiplomacyFaction::setTreaty(const std::string& treatyId, bool enabled)
+{
+	auto it = std::find(_treaties.begin(), _treaties.end(), treatyId);
+	if (enabled)
+	{
+		if (it == _treaties.end())
+		{
+			_treaties.push_back(treatyId);
+		}
+	}
+	else
+	{
+		if (it != _treaties.end())
+		{
+			_treaties.erase(it);
+		}
+	}
+}
+
+void DiplomacyFaction::setTreaty(TreatyName treaty, bool enabled)
+{
+	const char* id = treatyToId(treaty);
+	if (!id || !*id)
+	{
+		return;
+	}
+	setTreaty(std::string{id}, enabled);
+}
+
+int DiplomacyFaction::getActionCooldown(const std::string& actionType) const
+{
+	auto it = _actionCooldowns.find(actionType);
+	if (it == _actionCooldowns.end())
+	{
+		return 0;
+	}
+	return std::max(0, it->second);
+}
+
+bool DiplomacyFaction::isActionOnCooldown(const std::string& actionType) const
+{
+	return getActionCooldown(actionType) > 0;
+}
+
+void DiplomacyFaction::setActionCooldown(const std::string& actionType, int minutes)
+{
+	if (minutes <= 0)
+	{
+		_actionCooldowns.erase(actionType);
+		return;
+	}
+	_actionCooldowns[actionType] = minutes;
+}
+
+void DiplomacyFaction::tickActionCooldowns(int minutes)
+{
+	if (minutes <= 0 || _actionCooldowns.empty())
+	{
+		return;
+	}
+
+	for (auto it = _actionCooldowns.begin(); it != _actionCooldowns.end(); )
+	{
+		it->second -= minutes;
+		if (it->second <= 0)
+		{
+			it = _actionCooldowns.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
 }
 
 /**

--- a/src/Savegame/DiplomacyFaction.h
+++ b/src/Savegame/DiplomacyFaction.h
@@ -18,6 +18,8 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
+#include <map>
+#include <cstdint>
 #include "../Engine/Yaml.h"
 
 namespace OpenXcom
@@ -63,6 +65,7 @@ private:
 	std::vector<int> _dailyRepScore;
 	bool _discovered, _thisMonthDiscovered, _repLvlChanged;
 	std::vector<std::string> _treaties;
+	std::map<std::string, int> _actionCooldowns;
 	std::string _reputationName;
 	std::vector<std::string> _commandsToProcess, _eventsToProcess;
 	std::vector<RuleMissionScript*> _availableMissionScripts;
@@ -148,6 +151,18 @@ public:
 	void setThisMonthRepLvlChanged(bool status) { _repLvlChanged = status; }
 	/// Get mission script commands that pass all checks to generate alien mission for that faction.
 	const std::vector<RuleMissionScript*>& getAvalibleMissionScripts() const { return _availableMissionScripts; }
+
+	/// Treaty helpers (stored as string IDs in saves).
+	bool hasTreaty(const std::string& treatyId) const;
+	bool hasTreaty(TreatyName treaty) const;
+	void setTreaty(const std::string& treatyId, bool enabled);
+	void setTreaty(TreatyName treaty, bool enabled);
+
+	/// Diplomacy dialogue action cooldowns (in minutes).
+	int getActionCooldown(const std::string& actionType) const;
+	bool isActionOnCooldown(const std::string& actionType) const;
+	void setActionCooldown(const std::string& actionType, int minutes);
+	void tickActionCooldowns(int minutes);
 
 	/// Public manipulators to factional stores.
 	ItemContainer* getItems() const { return _items; }


### PR DESCRIPTION
Introduces a new diplomacy dialogue UI driven by ruleset-defined actions, allowing players to interact with factions through a list of configurable actions with custom conditions and effects. Adds RuleDiplomacyAction class, supporting action availability, effects, cooldowns, and special navigation. Updates Mod, GeoscapeState, and related classes to support loading, validation, and cooldown ticking for diplomacy actions. Includes documentation and test ruleset for the new system.

Improve diplomacy dialogue UI and action handling

Refactored DiplomacyDialogueState to add a dedicated close hint text field, improve layout and word wrapping, and enhance the actions list with better scrolling and selector offset handling. Updated TextList to support configurable selector offset and improved mouse over behavior. Cleaned up unused includes in RuleDiplomacyAction.cpp.
